### PR TITLE
Add calls to process headers as well

### DIFF
--- a/lib/yugo.ex
+++ b/lib/yugo.ex
@@ -46,6 +46,7 @@ defmodule Yugo do
           cc: [address],
           date: DateTime.t(),
           flags: [flag],
+          headers: list(list(String.t())),
           in_reply_to: nil | String.t(),
           message_id: nil | String.t(),
           reply_to: [address],

--- a/lib/yugo/client.ex
+++ b/lib/yugo/client.ex
@@ -399,6 +399,7 @@ defmodule Yugo.Client do
           |> Enum.reject(fn {key, _} -> Map.has_key?(msg, key) end)
           |> Enum.map(&elem(&1, 1))
 
+        parts_to_fetch = ["RFC822.HEADER" | parts_to_fetch]
         parts_to_fetch = ["BODY" | parts_to_fetch]
 
         conn =
@@ -585,6 +586,14 @@ defmodule Yugo.Client do
 
           conn
           |> put_in([Access.key!(:unprocessed_messages), seq_num, :flags], flags)
+        else
+          conn
+        end
+
+      {:fetch, {seq_num, :rfc822_header, rfc822_header}} ->
+        if Map.has_key?(conn.unprocessed_messages, seq_num) do
+          conn
+          |> put_in([Access.key!(:unprocessed_messages), seq_num, :rfc822_header], rfc822_header)
         else
           conn
         end

--- a/lib/yugo/client.ex
+++ b/lib/yugo/client.ex
@@ -589,10 +589,10 @@ defmodule Yugo.Client do
           conn
         end
 
-      {:fetch, {seq_num, :rfc822_header, rfc822_header}} ->
+      {:fetch, {seq_num, :headers, headers}} ->
         if Map.has_key?(conn.unprocessed_messages, seq_num) do
           conn
-          |> put_in([Access.key!(:unprocessed_messages), seq_num, :rfc822_header], rfc822_header)
+          |> put_in([Access.key!(:unprocessed_messages), seq_num, :headers], headers)
         else
           conn
         end

--- a/lib/yugo/client.ex
+++ b/lib/yugo/client.ex
@@ -399,8 +399,7 @@ defmodule Yugo.Client do
           |> Enum.reject(fn {key, _} -> Map.has_key?(msg, key) end)
           |> Enum.map(&elem(&1, 1))
 
-        parts_to_fetch = ["RFC822.HEADER" | parts_to_fetch]
-        parts_to_fetch = ["BODY" | parts_to_fetch]
+        parts_to_fetch = ["BODY" , "RFC822.HEADER" | parts_to_fetch]
 
         conn =
           conn

--- a/lib/yugo/parser.ex
+++ b/lib/yugo/parser.ex
@@ -225,6 +225,10 @@ defmodule Yugo.Parser do
       name == "BODY" ->
         parse_body(rest)
 
+      name == "RFC822.HEADER" ->
+        {headers, rest} = parse_string(rest)
+        {{:rfc822_header, headers}, rest}
+
       name == "UID" ->
         {uid, rest} = parse_number(rest)
         {{:uid, uid}, rest}

--- a/lib/yugo/parser.ex
+++ b/lib/yugo/parser.ex
@@ -226,8 +226,13 @@ defmodule Yugo.Parser do
         parse_body(rest)
 
       name == "RFC822.HEADER" ->
-        {headers, rest} = parse_string(rest)
-        {{:rfc822_header, headers}, rest}
+        {raw_headers, rest} = parse_string(rest)
+
+        {{:headers,
+          raw_headers
+            |> String.split("\r\n", trim: true)
+            |> Enum.map(&String.split(&1, ":", trim: true))
+        }, rest}
 
       name == "UID" ->
         {uid, rest} = parse_number(rest)

--- a/test/yugo/client_test.exs
+++ b/test/yugo/client_test.exs
@@ -24,7 +24,7 @@ defmodule Yugo.ClientTest do
     S: * 2 EXISTS
     C: DONE
     S: 4 OK idle done
-    C: 5 FETCH 2 (BODY FLAGS ENVELOPE)
+    C: 5 FETCH 2 (BODY RFC822.HEADER FLAGS ENVELOPE)
     S: * 2 FETCH (FLAGS (\sEEn) BODY ("text" "plain" ("charset" "us-ascii" "format" "flowed") NIL NIL "7bit" 47 6) ENVELOPE ("Wed, 07 Dec 2022 18:02:41 -0500" NIL (("Marge Simpson" NIL "marge" "simpsons-family.com")) (("Marge Simpson" NIL "marge" "simpsons-family.com")) (("Marge" NIL "marge" "simpsons-family.com")) (("HOMIEEEE" NIL "homer" "simpsons-family.com")) NIL NIL NIL "fjaelwkjfi oaf<$ ))) \""))
     S: 5 oK done
     C: 6 FETCH 2 (BODY.PEEK[1])
@@ -62,7 +62,7 @@ defmodule Yugo.ClientTest do
     S: * 2 EXISTS
     C: DONE
     S: 4 OK idle done
-    C: 5 FETCH 2 (BODY FLAGS ENVELOPE)
+    C: 5 FETCH 2 (BODY RFC822.HEADER FLAGS ENVELOPE)
     S: * 2 FETCH (FLAGS (\Recent) BODY (("text" "plain" ("charset" "us-ascii" "format" "flowed") NIL NIL "7bit" 34 4)("text" "x-elixir" ("charset" "us-ascii") NIL NIL "base64" 78 1) "mixed") ENVELOPE ("Wed, 07 Dec 2022 23:21:35 -0500" "Foo Bar Baz Buzz Biz Boz" (("Bob Jones" NIL "bobjones" "example.org")) (("Bob Jones" NIL "bobjones" "example.org")) (("Bob Jones" NIL "bobjones" "example.org")) ((NIL NIL "foo" "bar.com")) NIL NIL NIL "Fjaewlk jflkewajf i3ajf0943aF $#AF $#FA#$ F#AF {123}"))
     S: 5 oK done
     C: 6 FETCH 2 (BODY.PEEK[1] BODY.PEEK[2])
@@ -106,7 +106,7 @@ defmodule Yugo.ClientTest do
     S: * 2 EXISTS
     C: DONE
     S: 4 OK idle done
-    C: 5 FETCH 2 (BODY FLAGS ENVELOPE)
+    C: 5 FETCH 2 (BODY RFC822.HEADER FLAGS ENVELOPE)
     S: * 2 FETCH (FLAGS () BODY ("text" "plain" () NIL NIL "7bit" 5 1) ENVELOPE ("Wed, 07 Dec 2022 18:02:41 -0500" "Hello! (subject)" (("Marge Simpson" NIL "marge" "simpsons-family.com")) (("Marge Simpson" NIL "marge" "simpsons-family.com")(NIL NIL "bob" "bobs-email.com")) (("Marge" NIL "marge" "simpsons-family.com")) (("HOMIEEEE" NIL "homer" "simpsons-family.com")) ((NIL NIL "foo" "bar.com")("barfoo" NIL "bar" "foo.com")({0}
     S: NIL "fizz" "buzz.com")) NIL "123 abc 456" {0}
     S: ))
@@ -145,7 +145,7 @@ defmodule Yugo.ClientTest do
     S: * 2 exists
     C: DONE
     S: 4 ok * * * ok ok ok ok
-    C: 5 FETCH 2 (BODY FLAGS ENVELOPE)
+    C: 5 FETCH 2 (BODY RFC822.HEADER FLAGS ENVELOPE)
     S: * 2 FETCH (FLAGS (\Recent) BODY (("text" "plain" ("charset" "us-ascii") NIL NIL "7bit" 42 4)("text" "html" ("charset" "us-ascii") NIL NIL "7bit" 206 0) "alternative") ENVELOPE ("Thu, 08 Dec 2022 09:59:48 -0500" "An HTML email" (("Aych T. Emmel" NIL "person" "domain.com")) ((NIL NIL "person" "domain.com")) ((NIL NIL "foo" "bar.com")) ((NIL NIL "bar" "foo.com")) NIL NIL NIL "<><><><><>"))
     S: 5 OK Fetch completed (0.001 + 0.000 secs).
     C: 6 FETCH 2 (BODY.PEEK[1] BODY.PEEK[2])
@@ -196,7 +196,7 @@ defmodule Yugo.ClientTest do
     S: * 2 exists
     C: DONE
     S: 4 ok * * * ok ok ok ok
-    C: 5 FETCH 2 (BODY FLAGS ENVELOPE)
+    C: 5 FETCH 2 (BODY RFC822.HEADER FLAGS ENVELOPE)
     S: * 2 FETCH (uid 123 FLAGS () BODY #{body_structure} ENVELOPE ("Wed, 07 Dec 2022 18:02:41 -0500" NIL (("Marge Simpson" NIL "marge" "simpsons-family.com")) (("Marge Simpson" NIL "marge" "simpsons-family.com")) (("Marge" NIL "marge" "simpsons-family.com")) (("HOMIEEEE" NIL "homer" "simpsons-family.com")) NIL NIL nil niL))
     S: 5 OK OK OK
     C: 6 FETCH 2 (BODY.PEEK[1.1] BODY.PEEK[1.2] BODY.PEEK[1.3.1] BODY.PEEK[1.3.2] BODY.PEEK[2.1] BODY.PEEK[2.2] BODY.PEEK[3])

--- a/test/yugo/parser_test.exs
+++ b/test/yugo/parser_test.exs
@@ -82,4 +82,35 @@ defmodule Yugo.ParserTest do
     [fetch: {0, :flags, ["\\Seen", "\\Recent"]}, fetch: {0, :uid, 84}] =
       Parser.parse_response(~S|* 0 fetch (UID 84 FLags (\Seen \Recent))|)
   end
+
+  test "parse FETCH response with simple RFC822.HEADER" do
+    [
+      fetch: {1, :rfc822_header, "From: example@example.com\r\nSubject: Test Email\r\n\r\n"}
+    ] =
+      Parser.parse_response(
+        "* 1 FETCH (RFC822.HEADER \"From: example@example.com\r\nSubject: Test Email\r\n\r\n\")"
+      )
+
+  end
+
+  test "parse FETCH response with complex RFC822.HEADER" do
+    headers1 = "From: example@example.com\r\n" <>
+              "X-Spam-Checker-Version: SpamAssassin 3.4.6 (2021-04-09)\r\n" <>
+              "X-Spam-Level:\r\n" <>
+              "X-Spam-Pyzor:\r\n" <>
+              "X-Spam-Status: No, score=-100.0 required=6.0 shortcircuit=ham
+	autolearn=disabled version=3.4.6\r\n" <>
+              "Subject: Multi-Line Subject\r\n\t Continued Here\r\n" <>
+              "To: recipient1@example.com,\r\n recipient2@example.com\r\n" <>
+              "CC: cc@example.com\r\nBCC: bcc@example.com\r\n\r\n"
+    [
+      fetch: {2, :rfc822_header, headers2}
+    ] =
+      Parser.parse_response(
+        "* 2 FETCH (RFC822.HEADER \"#{headers1}\")"
+      )
+
+    assert headers1 == headers2
+
+  end
 end

--- a/test/yugo/parser_test.exs
+++ b/test/yugo/parser_test.exs
@@ -85,7 +85,7 @@ defmodule Yugo.ParserTest do
 
   test "parse FETCH response with simple RFC822.HEADER" do
     [
-      fetch: {1, :rfc822_header, "From: example@example.com\r\nSubject: Test Email\r\n\r\n"}
+      fetch: {1, :headers, [["From", " example@example.com"], ["Subject", " Test Email"]]}
     ] =
       Parser.parse_response(
         "* 1 FETCH (RFC822.HEADER \"From: example@example.com\r\nSubject: Test Email\r\n\r\n\")"
@@ -104,13 +104,12 @@ defmodule Yugo.ParserTest do
               "To: recipient1@example.com,\r\n recipient2@example.com\r\n" <>
               "CC: cc@example.com\r\nBCC: bcc@example.com\r\n\r\n"
     [
-      fetch: {2, :rfc822_header, headers2}
+      fetch: {2, :headers, [["From", " example@example.com"], ["X-Spam-Checker-Version", " SpamAssassin 3.4.6 (2021-04-09)"], ["X-Spam-Level"], ["X-Spam-Pyzor"], ["X-Spam-Status", " No, score=-100.0 required=6.0 shortcircuit=ham\n\tautolearn=disabled version=3.4.6"], ["Subject", " Multi-Line Subject"], ["\t Continued Here"], ["To", " recipient1@example.com,"], [" recipient2@example.com"], ["CC", " cc@example.com"], ["BCC", " bcc@example.com"]]}
     ] =
       Parser.parse_response(
         "* 2 FETCH (RFC822.HEADER \"#{headers1}\")"
       )
 
-    assert headers1 == headers2
 
   end
 end


### PR DESCRIPTION
For an archiving project I needed to be able to access all the headers of the mails as well.
This commit adds the string containing the original headers to the messages