### PR TITLE
feat: added create, move, capabilities, count, list, fetch

### DIFF
--- a/lib/yugo.ex
+++ b/lib/yugo.ex
@@ -260,4 +260,26 @@ defmodule Yugo do
       {:fetch, sequence_set}
     )
   end
+
+  @doc """
+  Retrieves the number of messages in the currently selected mailbox.
+
+  ## Parameters
+
+  * `client_name` - The name of the [`Client`](`Yugo.Client`) to use.
+
+  ## Returns
+
+  An integer representing the number of messages in the mailbox.
+
+  ## Example
+
+    iex> Yugo.count(:my_client)
+    42
+
+  """
+  @spec count(Client.name()) :: non_neg_integer()
+  def count(client_name) do
+    GenServer.call({:via, Registry, {Yugo.Registry, client_name}}, :count)
+  end
 end

--- a/lib/yugo.ex
+++ b/lib/yugo.ex
@@ -81,4 +81,22 @@ defmodule Yugo do
   def unsubscribe(client_name) do
     GenServer.cast({:via, Registry, {Yugo.Registry, client_name}}, {:unsubscribe, self()})
   end
+
+  @spec list(Client.name(), reference :: String.t(), mailbox :: String.t()) :: [
+          {:name, String.t()} | {:delimiter, String.t()} | {:attributes, [String.t()]}
+        ]
+  def list(client_name, reference \\ "", mailbox \\ "%") do
+    GenServer.call({:via, Registry, {Yugo.Registry, client_name}}, {:list, reference, mailbox})
+  end
+
+  @spec capabilities(Client.name()) :: [String.t()]
+  def capabilities(client_name) do
+    GenServer.call({:via, Registry, {Yugo.Registry, client_name}}, {:capabilities})
+  end
+
+  @spec has_capability?(Client.name(), String.t()) :: Bool.t()
+  def has_capability?(client_name, capability) do
+    capabilities(client_name)
+    |> Enum.any?(fn cap -> cap == capability end)
+  end
 end

--- a/lib/yugo.ex
+++ b/lib/yugo.ex
@@ -231,4 +231,33 @@ defmodule Yugo do
       {:create, mailbox_name}
     )
   end
+
+  @doc """
+  Fetches prior messages based on the given sequence set.
+
+  This function sends a request to fetch messages asynchronously. The fetched messages
+  will be delivered to subscribers just like new messages.
+
+  ## Parameters
+
+    * `client_name` - The name of the [`Client`](`Yugo.Client`) to use.
+    * `sequence_set` - A string representing the sequence set of messages to fetch.
+
+  ## Returns
+
+    * `:ok` immediately, as the operation is asynchronous.
+
+  ## Example
+
+      iex> Yugo.fetch(:my_client, "1:10")
+      :ok
+
+  """
+  @spec fetch(Client.name(), String.t()) :: :ok
+  def fetch(client_name, sequence_set) do
+    GenServer.cast(
+      {:via, Registry, {Yugo.Registry, client_name}},
+      {:fetch, sequence_set}
+    )
+  end
 end

--- a/lib/yugo.ex
+++ b/lib/yugo.ex
@@ -105,9 +105,7 @@ defmodule Yugo do
       ["INBOX", "Sent", "Drafts"]
 
   """
-  @spec list(Client.name(), reference :: String.t(), mailbox :: String.t()) :: [
-          {:name, String.t()} | {:delimiter, String.t()} | {:attributes, [String.t()]}
-        ]
+  @spec list(Client.name(), reference :: String.t(), mailbox :: String.t()) :: [String.t()]
   def list(client_name, reference \\ "", mailbox \\ "%") do
     GenServer.call({:via, Registry, {Yugo.Registry, client_name}}, {:list, reference, mailbox})
   end

--- a/lib/yugo.ex
+++ b/lib/yugo.ex
@@ -204,4 +204,31 @@ defmodule Yugo do
       {:move, sequence_set, destination, return_uids}
     )
   end
+
+  @doc """
+    Creates a new mailbox (aka folder) with the given name.
+
+    ## Parameters
+
+    * `client_name` - The name of the [`Client`](`Yugo.Client`) to use.
+    * `mailbox_name` - The name of the mailbox (aka folder) to create. Nested folders can be created by using a "/" delimiter.
+
+    ## Returns
+
+    * `:ok` if the mailbox was created successfully.
+    * `{:error, reason}` if the operation fails.
+
+    ## Example
+
+      iex> Yugo.create(:my_client, "Work/Projects")
+      :ok
+
+  """
+  @spec create(Client.name(), String.t()) :: :ok | {:error, String.t()}
+  def create(client_name, mailbox_name) do
+    GenServer.call(
+      {:via, Registry, {Yugo.Registry, client_name}},
+      {:create, mailbox_name}
+    )
+  end
 end

--- a/lib/yugo/client.ex
+++ b/lib/yugo/client.ex
@@ -180,10 +180,9 @@ defmodule Yugo.Client do
     send_command(conn, cmd, &on_move_response(&1, &2, &3, return_uids, from))
   end
 
-  defp on_move_response(conn, :ok, _response, _return_uids, from) do
-    # TODO: currently not collecting the uids of the moved messages
-    # result = if return_uids, do: Parser.parse_move_uids(response), else: :ok
-    GenServer.reply(from, :ok)
+  defp on_move_response(conn, :ok, response, return_uids, from) do
+    result = if return_uids, do: Parser.parse_move_uids(response), else: :ok
+    GenServer.reply(from, result)
     maybe_idle(conn)
   end
 

--- a/lib/yugo/client.ex
+++ b/lib/yugo/client.ex
@@ -248,13 +248,6 @@ defmodule Yugo.Client do
   end
 
   @impl true
-  def handle_info({:retry_count, from}, conn) do
-    count = conn.num_exists || 0
-    GenServer.reply(from, max(0, count))
-    {:noreply, conn}
-  end
-
-  @impl true
   def handle_continue(args, _state) do
     {:ok, socket} =
       if args[:tls] do
@@ -278,6 +271,13 @@ defmodule Yugo.Client do
       ssl_verify: args[:ssl_verify]
     }
 
+    {:noreply, conn}
+  end
+
+  @impl true
+  def handle_info({:retry_count, from}, conn) do
+    count = conn.num_exists || 0
+    GenServer.reply(from, max(0, count))
     {:noreply, conn}
   end
 

--- a/lib/yugo/client.ex
+++ b/lib/yugo/client.ex
@@ -158,6 +158,11 @@ defmodule Yugo.Client do
   end
 
   @impl true
+  def handle_call(:count, _from, conn) do
+    {:reply, conn.num_exists, conn}
+  end
+
+  @impl true
   def handle_call({:move, sequence_set, destination, return_uids}, from, conn) do
     conn =
       conn

--- a/lib/yugo/client.ex
+++ b/lib/yugo/client.ex
@@ -360,19 +360,21 @@ defmodule Yugo.Client do
   defp maybe_idle(conn) do
     if "IDLE" in conn.capabilities and not command_in_progress?(conn) and not conn.idling do
       timer = Process.send_after(self(), :idle_timeout, @idle_timeout)
-
-      %{conn | idling: true, idle_timer: timer, idle_timed_out: false}
-      |> send_command("IDLE", &on_idle_response/3)
+      conn = %{conn | idling: true, idle_timer: timer, idle_timed_out: false}
+      send_command(conn, "IDLE", &on_idle_response/3)
     else
       conn
     end
   end
 
   defp cancel_idle(conn) do
-    Process.cancel_timer(conn.idle_timer)
-
-    %{conn | idling: false, idle_timer: nil}
-    |> send_raw("DONE\r\n")
+    if conn.idling do
+      Process.cancel_timer(conn.idle_timer)
+      send_raw(conn, "DONE\r\n")
+      %{conn | idling: false, idle_timer: nil}
+    else
+      conn
+    end
   end
 
   defp maybe_process_messages(conn) do
@@ -514,12 +516,24 @@ defmodule Yugo.Client do
         %{conn | capabilities: caps}
 
       {:tagged_response, {tag, status, text}} when status == :ok ->
-        {%{on_response: resp_fn}, conn} = pop_in(conn, [Access.key!(:tag_map), tag])
+        {%{on_response: resp_fn, command: command}, conn} =
+          pop_in(conn, [Access.key!(:tag_map), tag])
 
-        resp_fn.(conn, status, text)
+        if String.contains?(command, "LIST") do
+          full_response = Enum.reverse(conn.list_response_acc)
+          conn = %{conn | list_response_acc: []}
+          resp_fn.(conn, status, full_response)
+        else
+          resp_fn.(conn, status, text)
+        end
 
       {:tagged_response, {tag, status, text}} when status in [:bad, :no] ->
-        raise "Got `#{status |> to_string() |> String.upcase()}` response status: `#{text}`. Command that caused this response: `#{conn.tag_map[tag].command}`"
+        if status == :bad and String.contains?(text, "Expected DONE") do
+          # This is likely due to an IDLE command being interrupted
+          %{conn | idling: false, idle_timer: nil}
+        else
+          raise "Got `#{status |> to_string() |> String.upcase()}` response status: `#{text}`. Command that caused this response: `#{conn.tag_map[tag].command}`"
+        end
 
       :continuation ->
         conn
@@ -628,6 +642,10 @@ defmodule Yugo.Client do
 
       {:fetch, {_seq_num, :uid, _uid}} ->
         conn
+
+      {:list, %{flags: flags, delimiter: delimiter, name: name}} ->
+        list_item = %{flags: flags, delimiter: delimiter, name: name}
+        %{conn | list_response_acc: [list_item | conn.list_response_acc]}
     end
   end
 

--- a/lib/yugo/client.ex
+++ b/lib/yugo/client.ex
@@ -202,7 +202,7 @@ defmodule Yugo.Client do
 
   defp on_list_response(conn, :ok, response, from) do
     mailbox_names = Enum.map(response, fn %{name: name} -> name end)
-    GenServer.reply(from, {:ok, mailbox_names})
+    GenServer.reply(from, mailbox_names)
     maybe_idle(conn)
   end
 
@@ -544,50 +544,6 @@ defmodule Yugo.Client do
         |> maybe_process_messages()
     end
   end
-
-  # defp process_earliest_message(conn) do
-  #   {seqnum, msg} = Enum.min_by(conn.unprocessed_messages, fn {k, _v} -> k end)
-
-  #   cond do
-  #     not Map.has_key?(msg, :fetched) ->
-  #       conn
-  #       |> fetch_message(seqnum)
-  #       |> maybe_process_messages()
-
-  #     msg.fetched == :filter ->
-  #       parts_to_fetch =
-  #         [flags: "FLAGS", envelope: "ENVELOPE"]
-  #         |> Enum.reject(fn {key, _} -> Map.has_key?(msg, key) end)
-  #         |> Enum.map(&elem(&1, 1))
-
-  #       parts_to_fetch = ["BODY" | parts_to_fetch]
-
-  #       conn =
-  #         conn
-  #         |> put_in([Access.key!(:unprocessed_messages), seqnum, :fetched], :pre_body)
-
-  #       unless Enum.empty?(parts_to_fetch) do
-  #         conn
-  #         |> send_command("FETCH #{seqnum} (#{Enum.join(parts_to_fetch, " ")})")
-  #       else
-  #         conn
-  #       end
-
-  #     msg.fetched == :pre_body ->
-  #       body_parts =
-  #         body_part_paths(msg.body_structure)
-  #         |> Enum.map(&"BODY.PEEK[#{&1}]")
-
-  #       conn
-  #       |> send_command("FETCH #{seqnum} (#{Enum.join(body_parts, " ")})", fn conn, :ok, _text ->
-  #         put_in(conn, [Access.key!(:unprocessed_messages), seqnum, :fetched], :full)
-  #       end)
-
-  #     msg.fetched == :full ->
-  #       conn
-  #       |> release_message(seqnum)
-  #   end
-  # end
 
   defp body_part_paths(body_structure, path_acc \\ []) do
     case body_structure do

--- a/lib/yugo/conn.ex
+++ b/lib/yugo/conn.ex
@@ -33,7 +33,8 @@ defmodule Yugo.Conn do
           filters: [{Yugo.Filter.t(), pid}],
           unprocessed_messages: %{integer: %{}},
           attrs_needed_by_filters: String.t(),
-          ssl_verify: :verify_none | :verify_peer
+          ssl_verify: :verify_none | :verify_peer,
+          list_response_acc: [%{flags: [String.t()], delimiter: String.t(), name: String.t()}]
         }
 
   @derive {Inspect, except: [:password]}
@@ -66,6 +67,7 @@ defmodule Yugo.Conn do
     idle_timed_out: false,
     filters: [],
     unprocessed_messages: %{},
-    attrs_needed_by_filters: ""
+    attrs_needed_by_filters: "",
+    list_response_acc: []
   ]
 end

--- a/lib/yugo/conn.ex
+++ b/lib/yugo/conn.ex
@@ -34,7 +34,8 @@ defmodule Yugo.Conn do
           unprocessed_messages: %{integer: %{}},
           attrs_needed_by_filters: String.t(),
           ssl_verify: :verify_none | :verify_peer,
-          list_response_acc: [%{flags: [String.t()], delimiter: String.t(), name: String.t()}]
+          list_response_acc: [%{flags: [String.t()], delimiter: String.t(), name: String.t()}],
+          fetch_queue: [integer]
         }
 
   @derive {Inspect, except: [:password]}
@@ -68,6 +69,7 @@ defmodule Yugo.Conn do
     filters: [],
     unprocessed_messages: %{},
     attrs_needed_by_filters: "",
-    list_response_acc: []
+    list_response_acc: [],
+    fetch_queue: []
   ]
 end

--- a/lib/yugo/parser.ex
+++ b/lib/yugo/parser.ex
@@ -165,9 +165,27 @@ defmodule Yugo.Parser do
         parse_msg_atts(fetchdata)
         |> Enum.map(fn {attr, value} -> {:fetch, {seqnum, attr, value}} end)
 
+      Regex.match?(~r/^LIST /i, resp) ->
+        [flags, delimiter, name] = parse_list_response(resp)
+        [list: %{flags: flags, delimiter: delimiter, name: name}]
+
       true ->
         []
     end
+  end
+
+  defp parse_list_response(resp) do
+    [_, flags, delimiter, name] = Regex.run(~r/^LIST \((.*?)\) (.*?) (.*)$/i, resp)
+
+    flags =
+      flags
+      |> String.split(" ")
+      |> Enum.map(&String.to_atom/1)
+
+    delimiter = if delimiter == "NIL", do: nil, else: String.trim(delimiter, "\"")
+    name = String.trim(name, "\"")
+
+    [flags, delimiter, name]
   end
 
   defp parse_msg_atts(rest), do: parse_msg_atts_aux(rest, [])

--- a/lib/yugo/parser.ex
+++ b/lib/yugo/parser.ex
@@ -120,6 +120,18 @@ defmodule Yugo.Parser do
         num = String.to_integer(num)
         [uid_next: num]
 
+      Regex.match?(~r/^\[COPYUID /i, resp) ->
+        [validity, source_uids, destination_uids] =
+          Regex.run(~r/^\[COPYUID (\d+) (\S+) (\S+)\]/i, resp, capture: :all_but_first)
+
+        [
+          copyuid: %{
+            validity: String.to_integer(validity),
+            source_uids: parse_uid_set(source_uids),
+            destination_uids: parse_uid_set(destination_uids)
+          }
+        ]
+
       true ->
         []
     end

--- a/lib/yugo/parser.ex
+++ b/lib/yugo/parser.ex
@@ -329,7 +329,14 @@ defmodule Yugo.Parser do
     {[name, _adl, mailbox, host], rest} =
       parse_list(rest, [&parse_nstring/1, &parse_nstring/1, &parse_nstring/1, &parse_nstring/1])
 
-    {{name, "#{String.downcase(mailbox)}@#{String.downcase(host)}"}, rest}
+    email =
+      case {mailbox, host} do
+        {nil, _} -> nil
+        {_, nil} -> nil
+        {m, h} -> "#{String.downcase(m)}@#{String.downcase(h)}"
+      end
+
+    {{name, email}, rest}
   end
 
   defp parse_address_list(rest) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Yugo.MixProject do
   def project do
     [
       app: :yugo,
-      version: "1.0.1",
+      version: "1.1.0",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -125,7 +125,7 @@ defmodule Helpers.Client do
     socket
   end
 
-  defp accept_ssl() do
+  defp accept_ssl(name \\ nil) do
     {:ok, listener} =
       :ssl.listen(0,
         packet: :line,
@@ -136,7 +136,7 @@ defmodule Helpers.Client do
       )
 
     {:ok, {_addr, port}} = :ssl.sockname(listener)
-    name = :crypto.strong_rand_bytes(5)
+    name = name || :crypto.strong_rand_bytes(5)
 
     opts = [
       username: "foo@example.com",
@@ -158,8 +158,8 @@ defmodule Helpers.Client do
     socket
   end
 
-  def ssl_server() do
-    accept_ssl()
+  def ssl_server(name \\ nil) do
+    accept_ssl(name)
     |> do_hello()
     |> do_select_bootstrap()
   end

--- a/test/yugo/client_test.exs
+++ b/test/yugo/client_test.exs
@@ -51,7 +51,8 @@ defmodule Yugo.ClientTest do
                    sender: [{"Marge Simpson", "marge@simpsons-family.com"}],
                    subject: nil,
                    to: [{"HOMIEEEE", "homer@simpsons-family.com"}],
-                   from: [{"Marge Simpson", "marge@simpsons-family.com"}]
+                   from: [{"Marge Simpson", "marge@simpsons-family.com"}],
+                   seqnum: 2
                  }
     end
   end
@@ -95,7 +96,8 @@ defmodule Yugo.ClientTest do
                    sender: [{"Bob Jones", "bobjones@example.org"}],
                    subject: "Foo Bar Baz Buzz Biz Boz",
                    to: [{nil, "foo@bar.com"}],
-                   from: [{"Bob Jones", "bobjones@example.org"}]
+                   from: [{"Bob Jones", "bobjones@example.org"}],
+                   seqnum: 2
                  }
     end
   end
@@ -134,7 +136,8 @@ defmodule Yugo.ClientTest do
                    ],
                    subject: "Hello! (subject)",
                    to: [{"HOMIEEEE", "homer@simpsons-family.com"}],
-                   from: [{"Marge Simpson", "marge@simpsons-family.com"}]
+                   from: [{"Marge Simpson", "marge@simpsons-family.com"}],
+                   seqnum: 2
                  }
     end
   end
@@ -180,7 +183,8 @@ defmodule Yugo.ClientTest do
                  sender: [{nil, "person@domain.com"}],
                  subject: "An HTML email",
                  to: [{nil, "bar@foo.com"}],
-                 from: [{"Aych T. Emmel", "person@domain.com"}]
+                 from: [{"Aych T. Emmel", "person@domain.com"}],
+                 seqnum: 2
                }
     end
   end
@@ -234,7 +238,8 @@ defmodule Yugo.ClientTest do
                    sender: [{"Marge Simpson", "marge@simpsons-family.com"}],
                    subject: nil,
                    to: [{"HOMIEEEE", "homer@simpsons-family.com"}],
-                   from: [{"Marge Simpson", "marge@simpsons-family.com"}]
+                   from: [{"Marge Simpson", "marge@simpsons-family.com"}],
+                   seqnum: 2
                  }
     end
   end

--- a/test/yugo/client_test.exs
+++ b/test/yugo/client_test.exs
@@ -434,4 +434,28 @@ defmodule Yugo.ClientTest do
     assert msg2.seqnum == 3
     assert msg3.seqnum == 4
   end
+
+  test "retrieves message count" do
+    socket = ssl_server(:test_count)
+    # Check the default count is returned
+    assert Yugo.count(:test_count) == 1
+
+    # Fake a second message
+    assert_comms(socket, ~S"""
+    S: * 2 EXISTS
+    C: DONE
+    S: 4 OK idle done
+    C: 5 FETCH 2 (BODY FLAGS ENVELOPE)
+    S: * 2 FETCH (FLAGS (\sEEn) BODY ("text" "plain" ("charset" "us-ascii" "format" "flowed") NIL NIL "7bit" 47 6) ENVELOPE ("Wed, 07 Dec 2022 18:02:41 -0500" NIL (("Marge Simpson" NIL "marge" "simpsons-family.com")) (("Marge Simpson" NIL "marge" "simpsons-family.com")) (("Marge" NIL "marge" "simpsons-family.com")) (("HOMIEEEE" NIL "homer" "simpsons-family.com")) NIL NIL NIL "fjaelwkjfi oaf<$ ))) \""))
+    S: 5 oK done
+    C: 6 FETCH 2 (BODY.PEEK[1])
+    S: * 2 fetcH (BODY[1] {14}
+    Hello 123
+    456)
+    S: 6 ok fetched
+    """)
+
+    # Check the count is updated
+    assert Yugo.count(:test_count) == 2
+  end
 end

--- a/test/yugo/client_test.exs
+++ b/test/yugo/client_test.exs
@@ -264,14 +264,13 @@ defmodule Yugo.ClientTest do
 
     # Wait for the result and assert
     assert Task.await(task) ==
-             {:ok,
-              [
-                "Public Folders",
-                "INBOX",
-                "Sent Items",
-                "Drafts",
-                "Trash"
-              ]}
+             [
+               "Public Folders",
+               "INBOX",
+               "Sent Items",
+               "Drafts",
+               "Trash"
+             ]
   end
 
   # todo add copy/store/expunge fallback when capabilities doesn't support move

--- a/test/yugo/parser_test.exs
+++ b/test/yugo/parser_test.exs
@@ -113,4 +113,15 @@ defmodule Yugo.ParserTest do
     assert Enum.at(destination_uids, 0) == 2001
     assert Enum.at(destination_uids, -1) == 3000
   end
+
+  test "parse LIST response" do
+    [list: %{flags: [:Noselect], delimiter: "/", name: "Public Folders"}] =
+      Parser.parse_response("* LIST (\Noselect) \"/\" \"Public Folders\"\r\n")
+
+    [list: %{flags: [:Unmarked, :HasNoChildren], delimiter: "/", name: "INBOX"}] =
+      Parser.parse_response("* LIST (\Unmarked \HasNoChildren) \"/\" \"INBOX\"\r\n")
+
+    [list: %{flags: [:Unmarked, :HasNoChildren], delimiter: "/", name: "Drafts"}] =
+      Parser.parse_response("* LIST (\Unmarked \HasNoChildren) \"/\" \"Drafts\"\r\n")
+  end
 end


### PR DESCRIPTION
Large run of changes here. Doc comments are present for each of the following new actions covering them in detail:

- `list`: returns the names of mailboxes that match the given pattern
- `capabilities`: A list of capabilities supported by the server
- `has_capability?`: Check of specific server support for a capability
- `move`: Move messages from current mailbox to a destination mailbox
- `create`: Create a new mailbox (aka folder)
- `fetch`: Fetches prior messages based on a sequence set. Messages are delivered to all subscribers just like new messages.

Also includes a few bug fixes and adjustments necessary to support the additional commands. 

I realize it's a fairly large PR, so this isn't a scope of features you want to merge, no worries. Or if you'd like some API related changes, let me know.