### PR TITLE
Add clearer error when remote is shutting down

### DIFF
--- a/lib/yugo/client.ex
+++ b/lib/yugo/client.ex
@@ -521,6 +521,9 @@ defmodule Yugo.Client do
       {:tagged_response, {tag, status, text}} when status in [:bad, :no] ->
         raise "Got `#{status |> to_string() |> String.upcase()}` response status: `#{text}`. Command that caused this response: `#{conn.tag_map[tag].command}`"
 
+      {:server_message, message} ->
+        raise "Server message: #{message}"
+
       :continuation ->
         conn
 

--- a/lib/yugo/parser.ex
+++ b/lib/yugo/parser.ex
@@ -125,6 +125,10 @@ defmodule Yugo.Parser do
     end
   end
 
+  defp parse_untagged_with_status(resp, :bye) do
+    [server_message: resp]
+  end
+
   defp parse_untagged_no_status(resp) do
     cond do
       Regex.match?(~r/^CAPABILITY /is, resp) ->

--- a/test/yugo/parser_test.exs
+++ b/test/yugo/parser_test.exs
@@ -102,4 +102,9 @@ defmodule Yugo.ParserTest do
     ] =
       Parser.parse_response("* 1 FETCH (ENVELOPE (NIL NIL NIL NIL NIL NIL NIL NIL NIL NIL))")
   end
+
+  test "parse BYE response" do
+    [server_message: "Server shutting down."] =
+      Parser.parse_response("* BYE Server shutting down.")
+  end
 end


### PR DESCRIPTION
Fixes #45 
Instead of crashing with an ambiguous message handle the situation orderly.